### PR TITLE
docs: remove per-page JS RUM snippets, update main.html for auto page tracking

### DIFF
--- a/docs/2-getting-started.md
+++ b/docs/2-getting-started.md
@@ -1,4 +1,3 @@
---8<-- "snippets/send-bizevent/2-getting-started.js"
 --8<-- "snippets/requirements.md"
 
 ## Prerequisites

--- a/docs/3-customer-business-journey.md
+++ b/docs/3-customer-business-journey.md
@@ -1,5 +1,4 @@
 # Customer Journey vs Business Journey
---8<-- "snippets/send-bizevent/3-customer-business-journey.js"
 
 ## Understanding Customer vs Business Journeys
 

--- a/docs/4-real-user-monitoring.md
+++ b/docs/4-real-user-monitoring.md
@@ -1,5 +1,4 @@
 # Real User Monitoring
---8<-- "snippets/send-bizevent/4-real-user-monitoring.js"
 
 Dynatrace Real User Monitoring (RUM) gives you the power to know your customers by providing performance analysis in real time. This includes all user actions taken and how the various actions impact performance. You can also easily identify problems or errors that occurred as well as user experience ratings, geolocation breakdowns, and much more. You can also gain insight into the behavior of your users. This among others includes the number of customers who return to your site. With Dynatrace RUM, you have the context over time and immediate analysis to the complete picture of your end-user experience.
 

--- a/docs/5-business-observability-rum.md
+++ b/docs/5-business-observability-rum.md
@@ -1,5 +1,4 @@
 # Business Observability with RUM
---8<-- "snippets/send-bizevent/5-business-observability-rum.js"
 
 Business events (BizEvents) are an important concept and central to Dynatrace Business Analytics. Business events generate business-grade data to enable important use cases.
 

--- a/docs/6-business-observability-automation.md
+++ b/docs/6-business-observability-automation.md
@@ -1,5 +1,4 @@
 # Business Observability Automation
---8<-- "snippets/send-bizevent/6-business-observability-automation.js"
 
 Dynatrace can be used to automate business observability use cases by orchestrating actions based on real-time business and system events. Through the Business Flow app, organizations can define and monitor key business processes—like order fulfillment or loan applications—using business events enriched with context from Dynatrace’s Smartscape topology. Workflows can automatically trigger alerts, notifications, or remediation actions when anomalies or service level objectives (SLOs) are breached, ensuring timely responses to issues that impact business outcomes. For example, a Workflow might notify business teams and open a service ticket if the average order processing time exceeds a defined threshold, helping align IT operations with business performance goals.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,3 @@
---8<-- "snippets/send-bizevent/index.js"
 
 --8<-- "snippets/dt-enablement.md"
 

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -8,3 +8,16 @@
     crossorigin="anonymous"></script>
   {% endif %}
 {% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  {% if config.extra.rum_snippet and page is defined and page.title %}
+  <script>
+    document.addEventListener('DOMContentLoaded', function() {
+      if (typeof dynatrace !== 'undefined') {
+        dynatrace.sendBizEvent('page_load', {'page': {{ page.title | tojson }}});
+      }
+    });
+  </script>
+  {% endif %}
+{% endblock %}

--- a/docs/snippets/send-bizevent/2-getting-started.js
+++ b/docs/snippets/send-bizevent/2-getting-started.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "2. Getting started"})
-});
-</script>

--- a/docs/snippets/send-bizevent/3-customer-business-journey.js
+++ b/docs/snippets/send-bizevent/3-customer-business-journey.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "3. Customer Journey vs Business Journey"})
-});
-</script>

--- a/docs/snippets/send-bizevent/4-real-user-monitoring.js
+++ b/docs/snippets/send-bizevent/4-real-user-monitoring.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "4. Real User Monitoring"})
-});
-</script>

--- a/docs/snippets/send-bizevent/5-business-observability-rum.js
+++ b/docs/snippets/send-bizevent/5-business-observability-rum.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "5. Business Observability with RUM"})
-});
-</script>

--- a/docs/snippets/send-bizevent/6-business-observability-automation.js
+++ b/docs/snippets/send-bizevent/6-business-observability-automation.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "6. Business Observability Automation"})
-});
-</script>

--- a/docs/snippets/send-bizevent/index.js
+++ b/docs/snippets/send-bizevent/index.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "1. About"})
-});
-</script>


### PR DESCRIPTION
## Summary

- Removes all `docs/snippets/*.js` files (per-page RUM bizEvent scripts)
- Removes `--8<-- "snippets/*.js"` includes from all markdown pages
- Updates `docs/overrides/main.html` to the framework v1.3.0 template

## Why

Page tracking via BizEvents is now handled centrally by `docs/overrides/main.html`, which:
1. Loads the RUM agent from `extra.rum_snippet` in `mkdocs.yaml`
2. Fires a `page_load` BizEvent on every page using the page title from the `nav` definition

Per-page JS snippet files were redundant and required manual maintenance for each new page.

## Test plan
- [ ] Verify docs build succeeds in CI
- [ ] Confirm no broken snippet includes remain in markdown files

🤖 Generated with [Claude Code](https://claude.com/claude-code)